### PR TITLE
Add link to "Wiki" in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # FAQ
 A set of frequently asked questions in Egyptian geeks group.
 
+The questions and answers can be found on the repository wiki at  
+**[github.com/egyptian-geeks/FAQ/wiki][wiki]**
+
 # What is this repository about?
 
 We noticed that there are some common questions asked in our group, and repeating them won't get us anywhere, so creating a central place for them is the most logical step we can take.
@@ -12,4 +15,9 @@ Any one can add and enhance content, if you see a question that is asked more th
 # Where are the FAQs then?
 
 You can find them in the "Wiki" tab.
+
+Can't see a "Wiki" link?  
+Go to **[github.com/egyptian-geeks/FAQ/wiki][wiki]**.
+
+[wiki]: https://github.com/egyptian-geeks/FAQ/wiki
 


### PR DESCRIPTION
There are 2 reasons for this change:
- Reading from mobile, I could not see a wiki tab in the navigation.
- Since the expected audience might include newbies, it might be helpful to just give them the link

The 2nd reason is why I added the link to the beginning of the file as well. It's also useful to get to the repository, and just "Click the big link" to get to the FAQs, even though we'll likely be sharing the wiki link more often than the project root.
